### PR TITLE
Added a --dry-run option to the licenser command

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ and very much in development.
 
 - ~~Add support for replacing an existing license~~ (thanks to @markwilson)
 - ~~Add built-in license options~~
-- Add dry-run option to see affected files before adding headers
+- ~~Add dry-run option to see affected files before adding headers~~
 - Add support for processing single files
-- Add support for placeholders in custom license files (such as year, owner etc.)
+- ~~Add support for placeholders in custom license files (such as year, owner etc.)~~
 
 ## Bug Reporting ##
 

--- a/src/JamesHalsall/Licenser/Command/LicenserCommand.php
+++ b/src/JamesHalsall/Licenser/Command/LicenserCommand.php
@@ -75,7 +75,18 @@ class LicenserCommand extends Command
                  'license to add the email address(es) of the license(es) to the license header. Can be a comma ' .
                  'separated list of email addresses or a single email address'
              )
-             ->addOption('remove-existing', 'r', InputOption::VALUE_NONE, 'Remove existing license headers');
+             ->addOption(
+                 'remove-existing',
+                 'r',
+                 InputOption::VALUE_NONE,
+                 'Remove existing license headers'
+             )
+             ->addOption(
+                 'dry-run',
+                 '',
+                 InputOption::VALUE_NONE,
+                 'If specified, the command will report a list of affected files but will make no modifications'
+             );
     }
 
     /**
@@ -103,6 +114,11 @@ class LicenserCommand extends Command
         $this->licenser->setOutputStream($output);
 
         $sources = $input->getArgument('sources');
-        $this->licenser->process($sources, (boolean) $input->getOption('remove-existing'));
+
+        $this->licenser->process(
+            $sources,
+            (bool) $input->getOption('remove-existing'),
+            (bool) $input->getOption('dry-run')
+        );
     }
 }


### PR DESCRIPTION
I have added a dry-run option to the Licenser command, this uses the existing
output messages to report affected files but will make no modifications to
any files if the option is passed to the command.

I have updated the output to include colour so that it's easier to read which
files are affected, and I have replaced occurrences of boolean with bool since
boolean is now deprecated. I have marked this feature (and another already
implemented feature) in the README as complete.