### PR TITLE
Rename the --remove-existing option to --replace-existing

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ values are used:
 
 ## Replacing an existing license ##
 
-You can tell the Licenser to replace an existing license header with a new one by just using the `--remove-existing` option
+You can tell the Licenser to replace an existing license header with a new one by using the `--replace-existing` option
 when running the command. This will tell Licenser to remove any existing licenses and replace them with the new one generated.
 
 ### Caution ###

--- a/src/JamesHalsall/Licenser/Command/LicenserCommand.php
+++ b/src/JamesHalsall/Licenser/Command/LicenserCommand.php
@@ -76,10 +76,10 @@ class LicenserCommand extends Command
                  'separated list of email addresses or a single email address'
              )
              ->addOption(
-                 'remove-existing',
+                 'replace-existing',
                  'r',
                  InputOption::VALUE_NONE,
-                 'Remove existing license headers'
+                 'Replace existing license headers'
              )
              ->addOption(
                  'dry-run',
@@ -117,7 +117,7 @@ class LicenserCommand extends Command
 
         $this->licenser->process(
             $sources,
-            (bool) $input->getOption('remove-existing'),
+            (bool) $input->getOption('replace-existing'),
             (bool) $input->getOption('dry-run')
         );
     }

--- a/src/JamesHalsall/Licenser/Licenser.php
+++ b/src/JamesHalsall/Licenser/Licenser.php
@@ -87,29 +87,28 @@ class Licenser
     /**
      * Processes a path and adds licenses
      *
-     * @param string $path           The path to the files/directory
-     * @param bool   $removeExisting True to remove existing license headers in files before adding
-     *                               new license (defaults to false)
-     * @param bool   $dryRun         True to report modified files and to not make any modifications
+     * @param string $path            The path to the files/directory
+     * @param bool   $replaceExisting True to replace existing license headers
+     * @param bool   $dryRun          True to report modified files and to not make any modifications
      */
-    public function process($path, $removeExisting = false, $dryRun = false)
+    public function process($path, $replaceExisting = false, $dryRun = false)
     {
         $iterator = $this->finder->name('*.php')
                                  ->in(realpath($path));
 
         foreach ($iterator as $file) {
-            $this->processFile($file, $removeExisting, $dryRun);
+            $this->processFile($file, $replaceExisting, $dryRun);
         }
     }
 
     /**
      * Processes a single file
      *
-     * @param SplFileInfo $file           The path to the file
-     * @param bool        $removeExisting True to remove existing license header before adding new one
-     * @param bool        $dryRun         True to report a modified file and to not make modifications
+     * @param SplFileInfo $file            The path to the file
+     * @param bool        $replaceExisting True to replace existing license header
+     * @param bool        $dryRun          True to report a modified file and to not make modifications
      */
-    private function processFile(SplFileInfo $file, $removeExisting, $dryRun)
+    private function processFile(SplFileInfo $file, $replaceExisting, $dryRun)
     {
         if ($file->isDir()) {
             return;
@@ -129,11 +128,11 @@ class Licenser
             }
         }
 
-        if (null !== $licenseTokenIndex && true === $removeExisting) {
+        if (null !== $licenseTokenIndex && true === $replaceExisting) {
             $this->removeExistingLicense($file, $tokens, $licenseTokenIndex, $dryRun);
         }
 
-        if (null === $licenseTokenIndex || true === $removeExisting) {
+        if (null === $licenseTokenIndex || true === $replaceExisting) {
             $this->log(sprintf('<fg=green>[+]</> Adding license header for <options=bold>%s</>', $file->getRealPath()));
 
             if (true === $dryRun) {


### PR DESCRIPTION
Renamed the `--remove-existing` option to `--replace-existing` – the reason being that a license cannot be removed without being replaced.